### PR TITLE
Fix Supabase middleware client configuration

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,30 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+
+type SupabaseCookie = { name: string; value: string };
 
 export async function middleware(req: NextRequest) {
-  const res = NextResponse.next();
+  const res = NextResponse.next({ request: { headers: req.headers } });
 
-  const supabase = createMiddlewareClient(
-    { req, res },
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      cookies: {
+        getAll(): SupabaseCookie[] {
+          return req.cookies
+            .getAll()
+            .map(cookie => ({ name: cookie.name, value: cookie.value }));
+        },
+        async setAll(
+          cookiesToSet: { name: string; value: string; options: CookieOptions }[]
+        ) {
+          for (const { name, value, options } of cookiesToSet) {
+            res.cookies.set(name, value, options as any);
+          }
+        },
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- replace the deprecated Supabase middleware helper with the `@supabase/ssr` server client
- wire request and response cookie helpers so middleware can refresh Supabase auth cookies

## Testing
- npx tsc --noEmit --pretty false *(fails: existing type errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dc90bb2ef083229818e871528e6f4c