### PR TITLE
Use user_notes table for private reader notes

### DIFF
--- a/src/components/InteractiveChapter.tsx
+++ b/src/components/InteractiveChapter.tsx
@@ -72,11 +72,11 @@ export default function InteractiveChapter({
 
   const saveNote = useCallback(async () => {
     const text = noteText.trim();
-    if (!text || !userId) return;
+    if (!text || !userId || notesFor == null) return;
 
     setIsSaving(true);
     try {
-      const { error } = await supabase.from("notes").insert({
+      const { error } = await supabase.from("user_notes").insert({
         user_id: userId,
         book_id: bookId,
         chapter: chapter,

--- a/src/components/NotesPanel.tsx
+++ b/src/components/NotesPanel.tsx
@@ -5,7 +5,7 @@ import type { Session, AuthChangeEvent } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabaseClient";
 
 type Note = {
-  id: number;
+  id: string;
   verse?: number | null;
   text: string;
   created_at: string;
@@ -52,7 +52,7 @@ export default function NotesPanel({
     setLoading(true);
     try {
       const { data, error } = await supabase
-        .from("notes")
+        .from("user_notes")
         .select("id, verse, text, created_at")
         .eq("user_id", userId)
         .eq("book_id", bookId)
@@ -83,7 +83,7 @@ export default function NotesPanel({
         {
           event: "*",
           schema: "public",
-          table: "notes",
+          table: "user_notes",
           filter: `user_id=eq.${userId}`,
         },
         () => fetchNotes()
@@ -97,13 +97,13 @@ export default function NotesPanel({
 
 
   // 4. Delete a note
-  const handleDelete = useCallback(async (id: number) => {
+  const handleDelete = useCallback(async (id: string) => {
     // We can use a custom modal here later instead of confirm
     const ok = window.confirm("Are you sure you want to delete this note?");
     if (!ok) return;
 
     try {
-      const { error } = await supabase.from("notes").delete().eq("id", id);
+      const { error } = await supabase.from("user_notes").delete().eq("id", id);
       if (error) throw error;
       // Realtime listener will handle the UI update
     } catch (err) {
@@ -113,10 +113,10 @@ export default function NotesPanel({
 
   if (!userId) {
     return (
-       <div className="rounded-xl border border-white/10 bg-white/[0.05] p-4 text-center">
-         <p className="text-sm text-white/70">Please sign in to view and save notes.</p>
-       </div>
-    )
+      <div className="rounded-xl border border-white/10 bg-white/[0.05] p-4 text-center">
+        <p className="text-sm text-white/70">Please sign in to view and save notes.</p>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- write reader note saves to the new `user_notes` Supabase table so entries stay tied to the current user
- load, watch, and delete notes from `user_notes` in the sidebar panel while keeping the sign-in guard intact
- align local note typing with the table's UUID ids to avoid type mismatches when interacting with Supabase

## Testing
- `npm run lint` *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc93c44dcc8322b62c7cf2d35f1a03